### PR TITLE
Added mixin for image when src used.

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -70,6 +70,7 @@ The following custom properties are available for styling:
 Custom property | Description | Default
 ----------------|-------------|----------
 `--iron-icon` | Mixin applied to the icon | {}
+`--iron-icon-image` | Mixin applied to the `src` image | {}
 `--iron-icon-width` | Width of the icon | `24px`
 `--iron-icon-height` | Height of the icon | `24px`
 `--iron-icon-fill-color` | Fill color of the svg icon | `currentcolor`
@@ -98,6 +99,9 @@ Custom property | Description | Default
         width: var(--iron-icon-width, 24px);
         height: var(--iron-icon-height, 24px);
         @apply(--iron-icon);
+      }
+      img {
+        @apply(--iron-icon-image);
       }
     </style>
   </template>


### PR DESCRIPTION
When `src` is specified, the `--iron-icon` mixin does not enable the user to apply styles directly to the created `img` tag. Adding a new mixin for this purposes allows users to style the image, for example adding `border-radius: 50%` for a rounded avatar.